### PR TITLE
Improve unicode support in msrest

### DIFF
--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -37,7 +37,6 @@ try:
 except ImportError:
     from urllib.parse import quote
 
-import chardet
 import isodate
 
 from .exceptions import (
@@ -798,18 +797,17 @@ class Deserializer(object):
          be returned.
         """
         if raw_data and isinstance(raw_data, bytes):
-            data = raw_data.decode(
-                encoding=chardet.detect(raw_data)['encoding'])
+            data = raw_data.decode(encoding='utf-8')
         else:
             data = raw_data
 
         if hasattr(raw_data, 'content'):
+            # This is a requests.Response
             if not raw_data.content:
                 return None
 
             if isinstance(raw_data.content, bytes):
-                encoding = chardet.detect(raw_data.content)["encoding"]
-                data = raw_data.content.decode(encoding=encoding)
+                data = raw_data.content.decode(encoding=raw_data.encoding)
             else:
                 data = raw_data.content
             try:

--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -801,16 +801,13 @@ class Deserializer(object):
         else:
             data = raw_data
 
-        if hasattr(raw_data, 'content'):
-            # This is a requests.Response
+        try:
+            # This is a requests.Response, json valid if nothing fail
             if not raw_data.text:
                 return None
-
-            try:
-                return json.loads(raw_data.text)
-            except (ValueError, TypeError):
-                return data
-
+            return json.loads(raw_data.text)
+        except (ValueError, TypeError, AttributeError):
+                pass
         return data
 
     def _instantiate_model(self, response, attrs):

--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -498,10 +498,10 @@ class Serializer(object):
         serialized = {}
         for key, value in attr.items():
             try:
-                serialized[str(key)] = self.serialize_data(
+                serialized[self.serialize_unicode(key)] = self.serialize_data(
                     value, dict_type, **kwargs)
             except ValueError:
-                serialized[str(key)] = None
+                serialized[self.serialize_unicode(key)] = None
         return serialized
 
     def serialize_object(self, attr, **kwargs):
@@ -523,10 +523,10 @@ class Serializer(object):
             serialized = {}
             for key, value in attr.items():
                 try:
-                    serialized[str(key)] = self.serialize_object(
+                    serialized[self.serialize_unicode(key)] = self.serialize_object(
                         value, **kwargs)
                 except ValueError:
-                    serialized[str(key)] = None
+                    serialized[self.serialize_unicode(key)] = None
             return serialized
 
         if obj_type == list:
@@ -898,9 +898,9 @@ class Deserializer(object):
         :rtype: dict
         """
         if isinstance(attr, list):
-            return {str(x['key']): self.deserialize_data(
+            return {x['key']: self.deserialize_data(
                 x['value'], dict_type) for x in attr}
-        return {str(k): self.deserialize_data(
+        return {k: self.deserialize_data(
             v, dict_type) for k, v in attr.items()}
 
     def deserialize_object(self, attr, **kwargs):
@@ -923,10 +923,10 @@ class Deserializer(object):
             deserialized = {}
             for key, value in attr.items():
                 try:
-                    deserialized[str(key)] = self.deserialize_object(
+                    deserialized[key] = self.deserialize_object(
                         value, **kwargs)
                 except ValueError:
-                    deserialized[str(key)] = None
+                    deserialized[key] = None
             return deserialized
 
         if obj_type == list:

--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -803,15 +803,11 @@ class Deserializer(object):
 
         if hasattr(raw_data, 'content'):
             # This is a requests.Response
-            if not raw_data.content:
+            if not raw_data.text:
                 return None
 
-            if isinstance(raw_data.content, bytes):
-                data = raw_data.content.decode(encoding=raw_data.encoding)
-            else:
-                data = raw_data.content
             try:
-                return json.loads(data)
+                return json.loads(raw_data.text)
             except (ValueError, TypeError):
                 return data
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         "requests_oauthlib>=0.5.0",
         "isodate>=0.5.4",
         "certifi>=2015.9.6.2",
-        "chardet>=2.3.0",
     ],
     extras_require={
         ":python_version<'3.4'": ['enum34>=1.0.4'],

--- a/test/unittest_serialization.py
+++ b/test/unittest_serialization.py
@@ -125,7 +125,6 @@ class TestModelDeserialization(unittest.TestCase):
         }
 
         resp = mock.create_autospec(Response)
-        resp.content = True # Hack, should not been read
         resp.text = json.dumps(data)
         resp.encoding = 'utf-8'
         model = self.d('GenericResource', resp)
@@ -706,7 +705,6 @@ class TestRuntimeDeserialized(unittest.TestCase):
         """
         response_data = mock.create_autospec(Response)
         response_data.encoding = 'utf-8'
-        response_data.content = True # Hack, should not been read
 
         response_data.text = ''
         response = self.d("[str]", response_data)
@@ -748,7 +746,7 @@ class TestRuntimeDeserialized(unittest.TestCase):
         """
 
         response_data = mock.create_autospec(Response)
-        response_data.content = json.dumps({"a":"b"})
+        response_data.text = json.dumps({"a":"b"})
         response_data.encoding = 'utf-8'
 
         class EmptyResponse(Model):
@@ -764,7 +762,7 @@ class TestRuntimeDeserialized(unittest.TestCase):
         Test deserializing an object with a malformed attributes_map.
         """
         response_data = mock.create_autospec(Response)
-        response_data.content = json.dumps({"a":"b"})
+        response_data.text = json.dumps({"a":"b"})
         response_data.encoding = 'utf-8'
 
         class BadResponse(Model):
@@ -805,7 +803,6 @@ class TestRuntimeDeserialized(unittest.TestCase):
 
         response_data.status_code = None
         response_data.headers = {'client-request-id':None, 'etag':None}
-        response_data.content = True # Should not been read
         response_data.text = ''
 
         response = self.d(self.TestObj, response_data)
@@ -818,14 +815,12 @@ class TestRuntimeDeserialized(unittest.TestCase):
         response_data = mock.create_autospec(Response)
         response_data.status_code = 200
         response_data.headers = {'client-request-id':"123", 'etag':456.3}
-        response_data.content = True # Should not been read
         response_data.text = ''
 
         response = self.d(self.TestObj, response_data)
         self.assertIsNone(response)
 
         message = {'AttrB':'1234'}
-        response_data.content = True # Hack, should not read this
         response_data.text = json.dumps(message)
         response_data.encoding = 'utf-8'
         response = self.d(self.TestObj, response_data)
@@ -844,7 +839,6 @@ class TestRuntimeDeserialized(unittest.TestCase):
         response_data = mock.create_autospec(Response)
         response_data.status_code = 200
         response_data.headers = {'client-request-id': 'a', 'etag': 'b'}
-        response_data.content = True # Hack, shoud not been read
         response_data.text = json.dumps(message)
         response_data.encoding = 'utf-8'
 
@@ -873,7 +867,6 @@ class TestRuntimeDeserialized(unittest.TestCase):
         response_data = mock.create_autospec(Response)
         response_data.status_code = 200
         response_data.headers = {'client-request-id': 'a', 'etag': 'b'}
-        response_data.content = True # Hack, should not been read
         response_data.text = json.dumps({'Key_C':True})
         response_data.encoding = 'utf-8'
 
@@ -901,7 +894,6 @@ class TestRuntimeDeserialized(unittest.TestCase):
         response_data = mock.create_autospec(Response)
         response_data.status_code = 200
         response_data.headers = {'client-request-id': 'a', 'etag': 'b'}
-        response_data.content = True # Hack, should not been read
         response_data.text = json.dumps({'AttrD': []})
         response_data.encoding = 'utf-8'
 
@@ -938,7 +930,6 @@ class TestRuntimeDeserialized(unittest.TestCase):
         response_data = mock.create_autospec(Response)
         response_data.status_code = 200
         response_data.headers = {'client-request-id': 'a', 'etag': 'b'}
-        response_data.content = True # Hack, should not been read
         response_data.text = json.dumps({'AttrF':[]})
         response_data.encoding = 'utf-8'
 
@@ -992,7 +983,6 @@ class TestRuntimeDeserialized(unittest.TestCase):
         response_data = mock.create_autospec(Response)
         response_data.status_code = 200
         response_data.headers = {'client-request-id': 'a', 'etag': 'b'}
-        response_data.content = True # Hack, should not been read
         response_data.text = json.dumps({"id":[{"ABC": "123"}]})
         response_data.encoding = 'utf-8'
 

--- a/test/unittest_serialization.py
+++ b/test/unittest_serialization.py
@@ -126,6 +126,7 @@ class TestModelDeserialization(unittest.TestCase):
 
         resp = mock.create_autospec(Response)
         resp.content = json.dumps(data)
+        resp.encoding = 'utf-8'
         model = self.d('GenericResource', resp)
         self.assertEqual(model.properties['platformFaultDomainCount'], 3)
         self.assertEqual(model.location, 'westus')
@@ -703,6 +704,7 @@ class TestRuntimeDeserialized(unittest.TestCase):
         Test direct deserialization of simple types.
         """
         response_data = mock.create_autospec(Response)
+        response_data.encoding = 'utf-8'
 
         response_data.content = json.dumps({})
         response = self.d("[str]", response_data)
@@ -745,6 +747,7 @@ class TestRuntimeDeserialized(unittest.TestCase):
 
         response_data = mock.create_autospec(Response)
         response_data.content = json.dumps({"a":"b"})
+        response_data.encoding = 'utf-8'
 
         class EmptyResponse(Model):
             _attribute_map = {}
@@ -760,6 +763,7 @@ class TestRuntimeDeserialized(unittest.TestCase):
         """
         response_data = mock.create_autospec(Response)
         response_data.content = json.dumps({"a":"b"})
+        response_data.encoding = 'utf-8'
 
         class BadResponse(Model):
             _attribute_map = None
@@ -818,6 +822,7 @@ class TestRuntimeDeserialized(unittest.TestCase):
 
         message = {'AttrB':'1234'}
         response_data.content = json.dumps(message)
+        response_data.encoding = 'utf-8'
         response = self.d(self.TestObj, response_data)
         self.assertTrue(hasattr(response, 'attr_b'))
         self.assertEqual(response.attr_b, int(message['AttrB']))
@@ -835,6 +840,7 @@ class TestRuntimeDeserialized(unittest.TestCase):
         response_data.status_code = 200
         response_data.headers = {'client-request-id': 'a', 'etag': 'b'}
         response_data.content = json.dumps(message)
+        response_data.encoding = 'utf-8'
 
         response = self.d(self.TestObj, response_data)
         self.assertTrue(hasattr(response, 'attr_a'))
@@ -862,6 +868,7 @@ class TestRuntimeDeserialized(unittest.TestCase):
         response_data.status_code = 200
         response_data.headers = {'client-request-id': 'a', 'etag': 'b'}
         response_data.content = json.dumps({'Key_C':True})
+        response_data.encoding = 'utf-8'
 
         response = self.d(self.TestObj, response_data)
 
@@ -888,6 +895,7 @@ class TestRuntimeDeserialized(unittest.TestCase):
         response_data.status_code = 200
         response_data.headers = {'client-request-id': 'a', 'etag': 'b'}
         response_data.content = json.dumps({'AttrD': []})
+        response_data.encoding = 'utf-8'
 
         response = self.d(self.TestObj, response_data)
         deserialized_list = [d for d in response.attr_d]
@@ -923,6 +931,7 @@ class TestRuntimeDeserialized(unittest.TestCase):
         response_data.status_code = 200
         response_data.headers = {'client-request-id': 'a', 'etag': 'b'}
         response_data.content = json.dumps({'AttrF':[]})
+        response_data.encoding = 'utf-8'
 
         response = self.d(self.TestObj, response_data)
         self.assertTrue(hasattr(response, 'attr_f'))
@@ -975,6 +984,7 @@ class TestRuntimeDeserialized(unittest.TestCase):
         response_data.status_code = 200
         response_data.headers = {'client-request-id': 'a', 'etag': 'b'}
         response_data.content = json.dumps({"id":[{"ABC": "123"}]})
+        response_data.encoding = 'utf-8'
 
         d = Deserializer({'ListObj':ListObj})
         response = d(CmplxTestObj, response_data)


### PR DESCRIPTION
I hate charset detection. It's not reliable and takes time. Moreover, msrest should not be responsible to do that anyway (and let requests extract it from the content-type string).
This PR changes the way we interpret the raw data to deserialize:
- If parameter is bytes, forces decoding to utf8 (do not guess with chardet)
- If parameter is requests.Response, use `encoding` attribute (let requests do the job)

In Autorest generated code, the parameter is always `requests.Response`

This comes from a CLI customer that has deserialisation issue. I sent them a preview version with this fix, will keep this open until we got the feedback.

FYI @derekbekoe @johanste