### PR TITLE
Allow model as input for type: 'object'

### DIFF
--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -512,6 +512,8 @@ class Serializer(object):
         obj_type = type(attr)
         if obj_type in self.basic_types:
             return self.serialize_basic(attr, self.basic_types[obj_type])
+        elif obj_type in self.dependencies.values():
+            return self._serialize(attr)
 
         if obj_type == dict:
             serialized = {}


### PR DESCRIPTION
Required for Data Factory

@lmazuel - lets chat about this scenario, whether this is the best approach or if anything further needs to be done.