### PR TITLE
Don't log Authorization header in http request

### DIFF
--- a/msrest/http_logger.py
+++ b/msrest/http_logger.py
@@ -43,7 +43,7 @@ def log_request(adapter, request, *args, **kwargs):
         _LOGGER.debug("Request method: %r", request.method)
         _LOGGER.debug("Request headers:")
         for header, value in request.headers.items():
-            if header == 'Authorization':
+            if header.lower() == 'authorization':
                 value = '*****'
             _LOGGER.debug("    %r: %r", header, value)
         _LOGGER.debug("Request body:")

--- a/msrest/http_logger.py
+++ b/msrest/http_logger.py
@@ -43,6 +43,8 @@ def log_request(adapter, request, *args, **kwargs):
         _LOGGER.debug("Request method: %r", request.method)
         _LOGGER.debug("Request headers:")
         for header, value in request.headers.items():
+            if header == 'Authorization':
+                value = '*****'
             _LOGGER.debug("    %r: %r", header, value)
         _LOGGER.debug("Request body:")
 


### PR DESCRIPTION
Keep secrets out of debug logs whenever possible. Prevents copy/paste accidents.