### PR TITLE
Fix unexpected setattr on class attribute if constant

### DIFF
--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -171,11 +171,14 @@ def _convert_to_datatype(data, data_type, localtypes):
                     localtypes) for key in data
             }
             data = data_obj(**result)
-        else:
+            constants = [name for name, config in getattr(data, '_validation', {}).items()
+                         if config.get('constant')]
             try:
-                for attr, map in data._attribute_map.items():
+                for attr, mapconfig in data._attribute_map.items():
+                    if attr in constants:
+                        continue
                     setattr(data, attr, _convert_to_datatype(
-                        getattr(data, attr), map['type'], localtypes))
+                        getattr(data, attr), mapconfig['type'], localtypes))
             except AttributeError:
                 pass
     return data


### PR DESCRIPTION
When a constant is used, a class attribute is created by Autorest.

The current msrest has a side effect to add an instance attribute on top of the class attribute on the _parameter_. 

Example, let's says "capacity" is a constant in `myobj`
```python
# capacity is not in `myobj.__dict__` (class attribute)
client.put_something(myobj)
# capacity IS in `myobj.__dict__` (was copied using setattr)
```

This breaks the `__eq__` contract (based on `__dict__`)

Thanks to @brettcannon for his help to debug this :)
