### PR TITLE
Raise DeserializationError on bad discriminator usage

### DIFF
--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -124,6 +124,10 @@ class Model(object):
             rest_api_response_key = _decode_attribute_map_key(cls._attribute_map[subtype_key]['key'])
             subtype_value = response.pop(rest_api_response_key, None) or response.pop(subtype_key, None)
             if subtype_value:
+                # Try to match base class. Can be class name only
+                # (bug to fix in Autorest to support x-ms-discriminator-name)
+                if cls.__name__ == subtype_value:
+                    return cls
                 flatten_mapping_type = cls._flatten_subtype(subtype_key, objects)
                 try:
                     return objects[flatten_mapping_type[subtype_value]]

--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -104,15 +104,6 @@ class Model(object):
         return str(self.__dict__)
 
     @classmethod
-    def _get_subtype_map(cls):
-        attr = '_subtype_map'
-        parents = cls.__bases__
-        for base in parents:
-            if hasattr(base, attr) and base._subtype_map:
-                return base._subtype_map
-        return {}
-
-    @classmethod
     def _flatten_subtype(cls, key, objects):
         if not '_subtype_map' in cls.__dict__:
             return {}
@@ -134,7 +125,12 @@ class Model(object):
             subtype_value = response.pop(rest_api_response_key, None) or response.pop(subtype_key, None)
             if subtype_value:
                 flatten_mapping_type = cls._flatten_subtype(subtype_key, objects)
-                return objects[flatten_mapping_type[subtype_value]]
+                try:
+                    return objects[flatten_mapping_type[subtype_value]]
+                except KeyError:
+                    raise DeserializationError("Subtype value {} has no mapping".format(subtype_value))
+            else:
+                raise DeserializationError("Discriminator {} cannot be absent or null".format(subtype_key))
         return cls
 
 def _decode_attribute_map_key(key):
@@ -817,7 +813,7 @@ class Deserializer(object):
         :param d_attrs: The deserialized response attributes.
         """
         if callable(response):
-            subtype = response._get_subtype_map()
+            subtype = getattr(response, '_subtype_map', {})
             try:
                 readonly = [k for k, v in response._validation.items()
                             if v.get('readonly')]

--- a/test/unittest_serialization.py
+++ b/test/unittest_serialization.py
@@ -1222,28 +1222,26 @@ class TestRuntimeDeserialized(unittest.TestCase):
                 self.d_type = 'siamese'
 
         message = {
-            "Animals": [ 
-            { 
-            "dType": "dog", 
-            "likesDogFood": True, 
-            "Name": "Fido" 
-            }, 
-            { 
-            "dType": "cat", 
-            "likesMice": False, 
-            "dislikes": { 
-            "dType": "dog", 
-            "likesDogFood": True, 
-            "Name": "Angry" 
-            }, 
-            "Name": "Felix" 
-            }, 
-            { 
-            "dType": "siamese", 
-            "Color": "grey", 
-            "likesMice": True, 
-            "Name": "Finch" 
-            }]}
+            "Animals": [{ 
+                "dType": "dog", 
+                "likesDogFood": True, 
+                "Name": "Fido" 
+            },{ 
+                "dType": "cat", 
+                "likesMice": False, 
+                "dislikes": { 
+                    "dType": "dog", 
+                    "likesDogFood": True, 
+                    "Name": "Angry" 
+                }, 
+                "Name": "Felix" 
+            },{ 
+                "dType": "siamese", 
+                "Color": "grey", 
+                "likesMice": True, 
+                "Name": "Finch" 
+            }]
+        }
 
         self.d.dependencies = {
             'Zoo':Zoo, 'Animal':Animal, 'Dog':Dog,
@@ -1266,6 +1264,24 @@ class TestRuntimeDeserialized(unittest.TestCase):
         self.assertIsInstance(animals[2], Siamese)
         self.assertEqual(animals[2].color, message['Animals'][2]["Color"])
         self.assertTrue(animals[2].likes_mice)
+
+        message = {
+            "Name": "Didier"
+        }
+        with self.assertRaises(DeserializationError) as err:
+            animal = self.d(Animal, message)
+        exception = err.exception
+        self.assertIn(str(exception), "Discriminator d_type cannot be absent or null")
+
+        message = { 
+            "dType": "Penguin", 
+            "likesDogFood": True, 
+            "Name": "Fido" 
+        }
+        with self.assertRaises(DeserializationError) as err:
+            animal = self.d(Animal, message)
+        exception = err.exception
+        self.assertIn(str(exception), "Subtype value Penguin has no mapping")
 
     def test_polymorphic_deserialization_with_escape(self):
 

--- a/test/unittest_serialization.py
+++ b/test/unittest_serialization.py
@@ -1266,6 +1266,14 @@ class TestRuntimeDeserialized(unittest.TestCase):
         self.assertTrue(animals[2].likes_mice)
 
         message = {
+            "Name": "Didier",
+            "dType": "Animal"
+        }
+        animal = self.d(Animal, message)
+        self.assertIsInstance(animal, Animal)
+        self.assertEquals(animal.name, "Didier")
+
+        message = {
             "Name": "Didier"
         }
         with self.assertRaises(DeserializationError) as err:


### PR DESCRIPTION
Was supposed to fix https://github.com/Azure/msrest-for-python/issues/26, but finally the discriminator must not be absent or null (and obviously not an unexpected value).

Raise a more easy to read exception, so that problem is more obvious to catch.