### PR TITLE
Fix incorrect Adapter life cycle

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup
 
 setup(
     name='msrest',
-    version='0.4.7',
+    version='0.4.8rc1',
     author='Microsoft Corporation',
     packages=['msrest'],
     url=("https://github.com/Azure/msrest-for-python"),

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -26,7 +26,8 @@
 
 import os
 from unittest import TestLoader, TextTestRunner
-
+import logging
+#logging.basicConfig(level=logging.DEBUG, filename="d:/log.txt")
 
 if __name__ == '__main__':
 

--- a/test/unittest_client.py
+++ b/test/unittest_client.py
@@ -37,10 +37,6 @@ from oauthlib import oauth2
 
 from msrest import ServiceClient
 from msrest.authentication import OAuthTokenAuthentication
-from msrest.pipeline import (
-    ClientHTTPAdapter,
-    ClientPipelineHook,
-    ClientRequest)
 
 from msrest import Configuration
 from msrest.exceptions import ClientRequestError, TokenExpiredError
@@ -99,23 +95,6 @@ class TestServiceClient(unittest.TestCase):
         client.add_header("test", "value")
 
         self.assertEqual(client._headers.get('test'), 'value')
-
-    def test_client_add_hook(self):
-
-        client = ServiceClient(self.creds, self.cfg)
-
-        def hook():
-            pass
-        
-        client.add_hook("request", hook)
-        self.assertTrue(hook in client._adapter._client_hooks['request'].precalls)
-
-        client.add_hook("request", hook, precall=False)
-        self.assertTrue(hook in client._adapter._client_hooks['request'].postcalls)
-
-        client.remove_hook("request", hook)
-        self.assertFalse(hook in client._adapter._client_hooks['request'].precalls)
-        self.assertFalse(hook in client._adapter._client_hooks['request'].postcalls)
 
     def test_format_url(self):
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps=
     -rdev_requirements.txt
     coverage
     flake8
-    autorest: requests==2.10.0
+    autorest: requests>=2.11.0
 commands=
     coverage run -m unittest discover -s . -p unittest*.py -t .. -v
     autorest: coverage run -a -m unittest discover -s "../autorest/src/generator/AutoRest.Python.Tests/AcceptanceTests" -p "*" -v


### PR DESCRIPTION
In current code, we create a `requests.HTTPAdapter` and assign it at instance variable of a client. At the same time, we create one session each time we have a request to do and we assign this adapter.
However, look at `requests` code, the `Session` object considers he has ownership of the `HTTPAdapter`. In some situation, the `Session` object it then closing the `HTTPAdapter`. Since we keep the adapter as an instance variable, if a session closes an adapter, the new session will get the same adapter and this exception will be raised:
```python
raise ClosedPoolError(self, "Pool is closed.")
```

This fixes https://github.com/Azure/azure-sdk-for-python/issues/1062

Note also that this PR fixes https://github.com/Azure/msrest-for-python/issues/4 and removes the "hook" feature and replace the few usage by the official `requests.hooks` feature (this requires too much extra work to keep our "hooks" and fix the adapter at the same time).

Note finally that the Autorest tests part of this PR will break until this PR is merged: https://github.com/Azure/autorest/pull/2143