### PR TITLE
Add requests hooks

### DIFF
--- a/msrest/configuration.py
+++ b/msrest/configuration.py
@@ -77,7 +77,7 @@ class Configuration(object):
         # Users hooks. Must respect requests hook callback signature
         # Note that we will inject the following parameters:
         # - kwargs['msrest']['session'] with the current session
-        self.user_hooks = []
+        self.hooks = []
 
         self._config = configparser.ConfigParser()
         self._config.optionxform = str

--- a/msrest/configuration.py
+++ b/msrest/configuration.py
@@ -74,7 +74,7 @@ class Configuration(object):
             requests.__version__,
             msrest_version)
 
-        # Users hooks. Must respect requests hook callback signature
+        # Requests hooks. Must respect requests hook callback signature
         # Note that we will inject the following parameters:
         # - kwargs['msrest']['session'] with the current session
         self.hooks = []

--- a/msrest/configuration.py
+++ b/msrest/configuration.py
@@ -74,6 +74,11 @@ class Configuration(object):
             requests.__version__,
             msrest_version)
 
+        # Users hooks. Must respect requests hook callback signature
+        # Note that we will inject the following parameters:
+        # - kwargs['msrest']['session'] with the current session
+        self.user_hooks = []
+
         self._config = configparser.ConfigParser()
         self._config.optionxform = str
 

--- a/msrest/service_client.py
+++ b/msrest/service_client.py
@@ -131,6 +131,18 @@ class ServiceClient(object):
             log_response(None, r.request, r, result=r)
         session.hooks['response'].append(log_hook)
 
+        def make_user_hook_cb(user_hook, session):
+            def user_hook_cb(r, *args, **kwargs):
+                kwargs.setdefault("msrest", {})
+                kwargs["msrest"] = {
+                    'session': session
+                }
+                user_hook(r, *args, **kwargs)
+            return user_hook_cb
+
+        for user_hook in self.config.user_hooks:
+            session.hooks['response'].append(make_user_hook_cb(user_hook, session))
+
         max_retries = config.get(
             'retries', self.config.retry_policy())
         for protocol in self._protocols:

--- a/msrest/service_client.py
+++ b/msrest/service_client.py
@@ -140,7 +140,7 @@ class ServiceClient(object):
                 user_hook(r, *args, **kwargs)
             return user_hook_cb
 
-        for user_hook in self.config.user_hooks:
+        for user_hook in self.config.hooks:
             session.hooks['response'].append(make_user_hook_cb(user_hook, session))
 
         max_retries = config.get(

--- a/msrest/service_client.py
+++ b/msrest/service_client.py
@@ -134,7 +134,7 @@ class ServiceClient(object):
         def make_user_hook_cb(user_hook, session):
             def user_hook_cb(r, *args, **kwargs):
                 kwargs.setdefault("msrest", {})['session'] = session
-                user_hook(r, *args, **kwargs)
+                return user_hook(r, *args, **kwargs)
             return user_hook_cb
 
         for user_hook in self.config.hooks:

--- a/msrest/service_client.py
+++ b/msrest/service_client.py
@@ -133,10 +133,7 @@ class ServiceClient(object):
 
         def make_user_hook_cb(user_hook, session):
             def user_hook_cb(r, *args, **kwargs):
-                kwargs.setdefault("msrest", {})
-                kwargs["msrest"] = {
-                    'session': session
-                }
+                kwargs.setdefault("msrest", {})['session'] = session
                 user_hook(r, *args, **kwargs)
             return user_hook_cb
 


### PR DESCRIPTION
This adds a new parameter in configuration "user_hooks" that can be a [response requests hook](http://docs.python-requests.org/en/master/user/advanced/#event-hooks).

Note that we inject the current sessions inside this hook using the kwargs of the callback. I don't expect any conflict since the key is "msrest" and that's not a requests parameter.

@brettcannon to confirm you're not shocked

FYI @yugangw-msft this is step 1 of "automatic provider registration"