### PR TITLE
Change Authentication hierarchy, fix #61

### DIFF
--- a/msrest/authentication.py
+++ b/msrest/authentication.py
@@ -79,6 +79,14 @@ class BasicTokenAuthentication(Authentication):
         self.scheme = 'Bearer'
         self.token = token
 
+    def set_token(self):
+        """Should be used to define the self.token attribute.
+
+        In this implementation, does nothing since the token is statically provided
+        at creation.
+        """
+        pass
+
     def signed_session(self):
         """Create requests session with any required auth headers
         applied.
@@ -91,7 +99,7 @@ class BasicTokenAuthentication(Authentication):
         return session
 
 
-class OAuthTokenAuthentication(Authentication):
+class OAuthTokenAuthentication(BasicTokenAuthentication):
     """OAuth Token Authentication.
     Requires that supplied token contains an expires_in field.
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -39,6 +39,7 @@ except ImportError:
 
 from msrest.authentication import (
     BasicAuthentication,
+    BasicTokenAuthentication,
     OAuthTokenAuthentication)
 
 from requests import Request
@@ -70,6 +71,19 @@ class TestAuthentication(unittest.TestCase):
         req = session.auth(self.request)
         self.assertTrue('Authorization' in req.headers)
         self.assertTrue(req.headers['Authorization'].startswith('Basic '))
+
+    def test_basic_token_auth(self):
+
+        token = {
+            'access_token': '123456789'
+        }
+        basic = BasicTokenAuthentication(token)
+        basic.set_token() # Just check that this does not raise
+        session = basic.signed_session()
+
+        req = session.prepare_request(self.request)
+        self.assertTrue('Authorization' in req.headers)
+        self.assertEquals(req.headers['Authorization'], 'Bearer 123456789')
 
     def test_token_auth(self):
 


### PR DESCRIPTION
FYI @schaabs 
This way you can rely on `isinstance(..., BasicTokenAuthentication)` and you are guaranteed that the following exists:
- credentials.token
- credentials.set_token()
- credentials.signed_session()