### PR TITLE
bug: minor fix on handling micro-second precisions

### DIFF
--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -1454,7 +1454,7 @@ class Deserializer(object):
                     else:
                         break
                 if len(decimal_str) > 6:
-                    attr = attr.replace(decimal_str, decimal_str[0:-1])
+                    attr = attr.replace(decimal_str, decimal_str[0:6])
 
             date_obj = isodate.parse_datetime(attr)
             test_utc = date_obj.utctimetuple()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1796,6 +1796,18 @@ class TestRuntimeDeserialized(unittest.TestCase):
         self.assertEqual(utc.tm_sec, 0)
         self.assertEqual(a.microsecond, 0)
 
+        # Only supports microsecond precision up to 6 digits, and chop off the rest
+        a = Deserializer.deserialize_iso('2018-01-20T18:35:24.666666312345Z')
+        utc = a.utctimetuple()
+
+        self.assertEqual(utc.tm_year, 2018)
+        self.assertEqual(utc.tm_mon, 1)
+        self.assertEqual(utc.tm_mday, 20)
+        self.assertEqual(utc.tm_hour, 18)
+        self.assertEqual(utc.tm_min, 35)
+        self.assertEqual(utc.tm_sec, 24)
+        self.assertEqual(a.microsecond, 666666)
+
         #with self.assertRaises(DeserializationError):
         #    a = Deserializer.deserialize_iso('1996-01-01T23:01:54-22:66') #TODO
 


### PR DESCRIPTION
2 notes:
1. I agree with the chopping logic, but we should ensure <=6 digits. Python's datetime object will error out when you supply more than that
2. I am also a bit skeptical on the [float conversion](https://github.com/Azure/msrest-for-python/blob/master/msrest/serialization.py#L844) which might miss a bit precision say from `.555` to `.549999`. But I don't have good context on that as we might have good reasons to do that.

//CC: @lmazuel @annatisch 