### PR TITLE
Add option to enable HTTP log (and disable by default)

### DIFF
--- a/doc/operation_config.rst
+++ b/doc/operation_config.rst
@@ -7,15 +7,16 @@ Methods on operations have extra parameters which can be provided in the kwargs.
 
 The options for operation configuration are:
 
-=============== ==== ====
-Parameter name  Type Role
-=============== ==== ====
-verify          bool Whether to verify the SSL certificate. Default is True.
-cert            str  Path to local certificate for client side verification.
-timeout         int  Timeout for establishing a server connection in seconds.
-allow_redirects bool Whether to allow redirects.
-max_redirects   int  Maimum number of allowed redirects.
-proxies         dict Proxy server settings.
-use_env_proxies bool Whether to read proxy settings from local environment variables.
-retries         int  Total number of retry attempts.
-=============== ==== ====
+================== ==== ====
+Parameter name     Type Role
+================== ==== ====
+verify             bool Whether to verify the SSL certificate. Default is True.
+cert               str  Path to local certificate for client side verification.
+timeout            int  Timeout for establishing a server connection in seconds.
+allow_redirects    bool Whether to allow redirects.
+max_redirects      int  Maimum number of allowed redirects.
+proxies            dict Proxy server settings.
+use_env_proxies    bool Whether to read proxy settings from local environment variables.
+retries            int  Total number of retry attempts.
+enable_http_logger bool Enable logs of HTTP in debug mode (False by default).
+================== ==== ====

--- a/msrest/configuration.py
+++ b/msrest/configuration.py
@@ -87,6 +87,9 @@ class Configuration(object):
             requests.__version__,
             msrest_version)
 
+        # Should we log HTTP requests/response?
+        self.enable_http_logger = False
+
         # Requests hooks. Must respect requests hook callback signature
         # Note that we will inject the following parameters:
         # - kwargs['msrest']['session'] with the current session

--- a/msrest/service_client.py
+++ b/msrest/service_client.py
@@ -125,10 +125,14 @@ class ServiceClient(object):
             return redirect_logic(resp, req, **kwargs) if attempt else []
 
         session.resolve_redirects = wrapped_redirect
-        def log_hook(r, *args, **kwargs):
-            log_request(None, r.request)
-            log_response(None, r.request, r, result=r)
-        session.hooks['response'].append(log_hook)
+        # if "enable_http_logger" is defined at the operation level, take the value.
+        # if not, take the one in the client config
+        # if not, disable http_logger
+        if config.get("enable_http_logger", self.config.enable_http_logger):
+            def log_hook(r, *args, **kwargs):
+                log_request(None, r.request)
+                log_response(None, r.request, r, result=r)
+            session.hooks['response'].append(log_hook)
 
         def make_user_hook_cb(user_hook, session):
             def user_hook_cb(r, *args, **kwargs):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -66,6 +66,37 @@ class TestServiceClient(unittest.TestCase):
         output_kwargs = client._configure_session(local_session, **{"test": True})
         self.assertTrue(output_kwargs['used_callback'])
 
+    def test_no_log(self):
+
+        client = ServiceClient(self.creds, self.cfg)
+        
+        # By default, no log handler for HTTP
+        local_session = requests.Session()
+        client._configure_session(local_session)
+        self.assertEqual(len(local_session.hooks["response"]), 0)
+
+        # I can enable it per request
+        local_session = requests.Session()
+        client._configure_session(local_session, **{"enable_http_logger": True})
+        self.assertEqual(len(local_session.hooks["response"]), 1)
+
+        # I can enable it per request (bool value should be honored)
+        local_session = requests.Session()
+        client._configure_session(local_session, **{"enable_http_logger": False})
+        self.assertEqual(len(local_session.hooks["response"]), 0)
+
+        # I can enable it globally
+        client.config.enable_http_logger = True
+        local_session = requests.Session()
+        client._configure_session(local_session)
+        self.assertEqual(len(local_session.hooks["response"]), 1)
+
+        # I can enable it globally and override it locally
+        client.config.enable_http_logger = True
+        local_session = requests.Session()
+        client._configure_session(local_session, **{"enable_http_logger": False})
+        self.assertEqual(len(local_session.hooks["response"]), 0)
+
     def test_client_request(self):
 
         client = ServiceClient(self.creds, self.cfg)


### PR DESCRIPTION
@derekbekoe @johanste 
This disables HTTP log by default and add two ways to configure it:
- At the operation level: `create_or_update(....., enable_http_log=True)`
- At the client level: `client.config.enable_http_log=True`
Operation level is most important (i.e. if operation says `False` and client says `True`, we don't log)

I would recommend the CLI to add `client.config.enable_http_log=True` in the generic client factory. And to override it by `False` for known critical operation if necessary (KeyVault? etc.)

I don't merge until you tell me the CLI is ready.