### PR TITLE
[docs only] minor grammar fix

### DIFF
--- a/msrest/exceptions.py
+++ b/msrest/exceptions.py
@@ -118,7 +118,7 @@ class ClientRequestError(ClientException):
 
 
 class AuthenticationError(ClientException):
-    """Client request failed to authentication."""
+    """Client request failed to authenticate."""
     pass
 
 


### PR DESCRIPTION
Was:
Client request failed to authentication.

Now:
Client request failed to authenticate.