### PR TITLE
Add support for `long` in basic types

### DIFF
--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -378,6 +378,10 @@ class Serializer(object):
     """Request object model serializer."""
 
     basic_types = {str: 'str', int: 'int', bool: 'bool', float: 'float'}
+    try:
+        basic_types[long] = 'int'
+    except NameError:
+        pass
     _xml_basic_types_serializers = {'bool': lambda x:str(x).lower()}
     days = {0: "Mon", 1: "Tue", 2: "Wed", 3: "Thu",
             4: "Fri", 5: "Sat", 6: "Sun"}
@@ -1172,6 +1176,10 @@ class Deserializer(object):
     """
 
     basic_types = {str: 'str', int: 'int', bool: 'bool', float: 'float'}
+    try:
+        basic_types[long] = 'int'
+    except NameError:
+        pass
     valid_date = re.compile(
         r'\d{4}[-]\d{2}[-]\d{2}T\d{2}:\d{2}:\d{2}'
         r'\.?\d*Z?[-+]?[\d{2}]?:?[\d{2}]?')

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1257,6 +1257,25 @@ class TestRuntimeSerialized(unittest.TestCase):
 
         self.assertEqual(serialized, expected_message)
 
+    def test_long_as_type_object(self):
+        """Test irrelevant on Python 3. But still doing it to test regresssion.
+            https://github.com/Azure/msrest-for-python/pull/121
+        """
+
+        if sys.version_info > (3,):
+            long_type = int
+        else:
+            long_type = long
+
+        class TestModel(Model):
+            _attribute_map = {'data': {'key': 'data', 'type': 'object'}}
+
+        m = TestModel(data = {'id': long_type(1)})
+        serialized = m.serialize()
+        assert serialized == {
+            'data': {'id': long_type(1)}
+        }
+
 
 class TestRuntimeDeserialized(unittest.TestCase):
 
@@ -2319,6 +2338,22 @@ class TestRuntimeDeserialized(unittest.TestCase):
             'ABC': TestEnum2.val2
         })
         self.assertEquals(obj.abc, TestEnum.val)
+
+    def test_long_as_type_object(self):
+        """Test irrelevant on Python 3. But still doing it to test regresssion.
+            https://github.com/Azure/msrest-for-python/pull/121
+        """
+
+        if sys.version_info > (3,):
+            long_type = int
+        else:
+            long_type = long
+
+        class TestModel(Model):
+            _attribute_map = {'data': {'key': 'data', 'type': 'object'}}
+
+        m = TestModel.deserialize({'data': {'id': long_type(1)}})
+        assert m.data['id'] == long_type(1)
 
 class TestModelInstanceEquality(unittest.TestCase):
 


### PR DESCRIPTION
On python 2.7, the following error occurs if you include a `long` in an `object` type:

```
SerializationError: Unable to build a model: Unable to deserialize response data. Data: {u'id': 1L}, object, TypeError: Cannot deserialize generic object with type: <type 'long'>, DeserializationError: Unable to deserialize response data. Data: {u'id': 1L}, object, TypeError: Cannot deserialize generic object with type: <type 'long'>
```

This change adds `long` (if it exists) to `basic_types` so that it can be serialized/deserialized properly.