### PR TITLE
If date is already a str, just validate and send

### DIFF
--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -997,6 +997,7 @@ class Serializer(object):
 
     @staticmethod
     def serialize_iso(attr, **kwargs):
+        # (Union[str, datetime.datetime], Dict[str, Any]) -> str
         """Serialize Datetime object into ISO-8601 formatted string.
 
         :param Datetime attr: Object to be serialized.
@@ -1004,7 +1005,9 @@ class Serializer(object):
         :raises: SerializationError if format invalid.
         """
         if isinstance(attr, str):
-            attr = isodate.parse_datetime(attr)
+            # Just check if valid date, and return it as-is
+            isodate.parse_datetime(attr)
+            return attr
         try:
             if not attr.tzinfo:
                 _LOGGER.warning(

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -729,6 +729,10 @@ class TestRuntimeSerialized(unittest.TestCase):
         date_str = Serializer.serialize_iso(date_obj)
         assert date_str == '2012-02-24T00:53:52.780Z'
 
+        date_str_in = "2019-06-10T10:50:10.1234567890123456789Z"
+        date_str_out = Serializer.serialize_iso(date_str_in)
+        assert date_str_in is date_str_out
+
     def test_serialize_primitive_types(self):
 
         a = self.s.serialize_data(1, 'int')


### PR DESCRIPTION
This allows to send nanoseconds string. See https://github.com/Azure/msrest-for-python/issues/149 for full picture