### PR TITLE
Added support for domainCredentials for authenticating to EventGrid domains.

### DIFF
--- a/msrest/authentication.py
+++ b/msrest/authentication.py
@@ -250,4 +250,22 @@ class TopicCredentials(ApiKeyCredentials):
                 self._topic_key_header: topic_key,
             }
         )
-    
+
+class DomainCredentials(ApiKeyCredentials):
+    """Event Grid domain authentication.
+
+    :param str domain_key: The Event Grid domain key
+    """
+
+    _domain_key_header = 'aeg-sas-key'
+
+    def __init__(self, domain_key):
+        # type: (str) -> None
+        if not domain_key:
+            raise ValueError("Domain key cannot be None")
+        super(DomainCredentials, self).__init__(
+            in_headers={
+                self._domain_key_header: domain_key,
+            }
+        )
+        

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -43,7 +43,8 @@ from msrest.authentication import (
     OAuthTokenAuthentication,
     ApiKeyCredentials,
     CognitiveServicesCredentials,
-    TopicCredentials
+    TopicCredentials,
+    DomainCredentials
 )
 
 from requests import Request, PreparedRequest
@@ -132,6 +133,12 @@ class TestAuthentication(unittest.TestCase):
         session = auth.signed_session()
         prep_req = session.prepare_request(self.request)
         self.assertDictContainsSubset({'aeg-sas-key' : 'mytopickey'}, prep_req.headers)
+
+    def test_eventgrid_domain_auth(self):
+        auth = DomainCredentials("mydomainkey")
+        session = auth.signed_session()
+        prep_req = session.prepare_request(self.request)
+        self.assertDictContainsSubset({'aeg-sas-key' : 'mydomainkey'}, prep_req.headers)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added a new DomainCredentials class for make it easier to supply EventGrid domain credentials. Event Grid domain is a recently introduced concept/resource and applications can publish events to an EventGrid domain for which an api key needs to be provided, and this newly introduced DomainCredentials class makes it easy to do so.