### PR TITLE
Undefined name: from configparser import NoOptionError

### DIFF
--- a/msrest/universal_http/requests.py
+++ b/msrest/universal_http/requests.py
@@ -33,6 +33,11 @@ import threading
 from typing import TYPE_CHECKING, List, Callable, Iterator, Any, Union, Dict, Optional  # pylint: disable=unused-import
 import warnings
 
+try:
+    from configparser import NoOptionError
+except ImportError:
+    from ConfigParser import NoOptionError  # type: ignore
+
 from oauthlib import oauth2
 import requests
 from requests.models import CONTENT_CHUNK_SIZE


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/Azure/msrest-for-python on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./msrest/universal_http/requests.py:454:47: F821 undefined name 'NoOptionError'
        except (ValueError, EnvironmentError, NoOptionError):
                                              ^
./tests/test_serialization.py:1265:25: F821 undefined name 'long'
            long_type = long
                        ^
./tests/test_serialization.py:2202:25: F821 undefined name 'long'
            long_type = long
                        ^
3     F821 undefined name 'NoOptionError'
3
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree