### PR TITLE
fix for paging

### DIFF
--- a/msrest/paging.py
+++ b/msrest/paging.py
@@ -123,7 +123,7 @@ class Paged(AsyncPagedMixin, Iterator):
         :return: The current page list
         :rtype: list
         """
-        if self.next_link is None:
+        if self.next_link is None or self.next_link == '':
             raise StopIteration("End of paging")
         self._current_page_iter_index = 0
         self._response = self._get_next(self.next_link)


### PR DESCRIPTION
Some services may return nextPage = "".

For instance, when calling:

```
az rest --method get --uri /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.AlertsManagement/alerts --debug --uri-parameters api-version=2019
-05-05-preview
```

I got following response:

```
{
  "nextLink": "",
  "value": []
}
```

This issue was causing following example to hang up:

https://github.com/hmcts/rdo-serviceops-dash/blob/master/app/temp_scripts/alerts.py

with following stacktrace:

```
Traceback (most recent call last):
  File "alerts.py", line 36, in <module>
    get_alerts(alerts)
  File "alerts.py", line 25, in get_alerts
    for alert in alerts:
  File "/env/lib/python3.6/site-packages/msrest/paging.py", line 144, in __next__
    return self.__next__()
  File "/env/lib/python3.6/site-packages/msrest/paging.py", line 144, in __next__
    return self.__next__()
  File "/env/lib/python3.6/site-packages/msrest/paging.py", line 144, in __next__
    return self.__next__()
  File "/env/lib/python3.6/site-packages/msrest/paging.py", line 143, in __next__
    self.advance_page()
  File "/env/lib/python3.6/site-packages/msrest/paging.py", line 129, in advance_page
    self._response = self._get_next(self.next_link)
  File "/env/lib/python3.6/site-packages/azure/mgmt/alertsmanagement/operations/alerts_operations.py", line 195, in internal_paging
    response = self._client.send(request, stream=False, **operation_config)
  File "/env/lib/python3.6/site-packages/msrest/service_client.py", line 336, in send
    pipeline_response = self.config.pipeline.run(request, **kwargs)
  File "/env/lib/python3.6/site-packages/msrest/pipeline/__init__.py", line 197, in run
    return first_node.send(pipeline_request, **kwargs)  # type: ignore
  File "/env/lib/python3.6/site-packages/msrest/pipeline/__init__.py", line 150, in send
    response = self.next.send(request, **kwargs)
  File "/env/lib/python3.6/site-packages/msrest/pipeline/requests.py", line 72, in send
    return self.next.send(request, **kwargs)
  File "/env/lib/python3.6/site-packages/msrest/pipeline/requests.py", line 137, in send
    return self.next.send(request, **kwargs)
  File "/env/lib/python3.6/site-packages/msrest/pipeline/__init__.py", line 150, in send
    response = self.next.send(request, **kwargs)
  File "/env/lib/python3.6/site-packages/msrest/pipeline/requests.py", line 193, in send
    self.driver.send(request.http_request, **kwargs)
  File "/env/lib/python3.6/site-packages/msrest/universal_http/requests.py", line 333, in send
    return super(RequestsHTTPSender, self).send(request, **requests_kwargs)
  File "/env/lib/python3.6/site-packages/msrest/universal_http/requests.py", line 142, in send
    **kwargs)
  File "/env/lib/python3.6/site-packages/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/env/lib/python3.6/site-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/env/lib/python3.6/site-packages/requests/adapters.py", line 449, in send
    timeout=timeout
  File "/env/lib/python3.6/site-packages/urllib3/connectionpool.py", line 600, in urlopen
    chunked=chunked)
  File "/env/lib/python3.6/site-packages/urllib3/connectionpool.py", line 343, in _make_request
    self._validate_conn(conn)
  File "/env/lib/python3.6/site-packages/urllib3/connectionpool.py", line 839, in _validate_conn
    conn.connect()
  File "/env/lib/python3.6/site-packages/urllib3/connection.py", line 344, in connect
    ssl_context=context)
  File "/env/lib/python3.6/site-packages/urllib3/util/ssl_.py", line 347, in ssl_wrap_socket
    return context.wrap_socket(sock, server_hostname=server_hostname)
  File "/env/lib/python3.6/site-packages/urllib3/contrib/pyopenssl.py", line 458, in wrap_socket
    if not util.wait_for_read(sock, sock.gettimeout()):
  File "/env/lib/python3.6/site-packages/urllib3/util/wait.py", line 143, in wait_for_read
    return wait_for_socket(sock, read=True, timeout=timeout)
  File "/env/lib/python3.6/site-packages/urllib3/util/wait.py", line 104, in poll_wait_for_socket
    return bool(_retry_on_intr(do_poll, timeout))
  File "/env/lib/python3.6/site-packages/urllib3/util/wait.py", line 42, in _retry_on_intr
    return fn(timeout)
  File "/env/lib/python3.6/site-packages/urllib3/util/wait.py", line 102, in do_poll
    return poll_obj.poll(t)
KeyboardInterrupt
```
