### PR TITLE
Handle empty enum values

### DIFF
--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -1610,7 +1610,7 @@ class Deserializer(object):
         :rtype: Enum
         :raises: DeserializationError if string is not valid enum value.
         """
-        if isinstance(data, enum_obj):
+        if isinstance(data, enum_obj) or data is None:
             return data
         if isinstance(data, Enum):
             data = data.value


### PR DESCRIPTION
Fix for logged warnings where service returns an empty (`None`) value for an enum.
These warnings were encountered during header deserialization.