### PR TITLE
Add __hash__ to RecordSet to allow python3 hash key/set use

### DIFF
--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -171,6 +171,10 @@ class Model(object):
         """Compare objects by comparing all attributes."""
         return not self.__eq__(other)
 
+    def __hash__(self):
+        """Compute a hash of this model by hashing all attributes."""
+        return sum([hash('{}:{}'.format(k, v)) for k, v in self.__dict__.items()])
+
     def __str__(self):
         return str(self.__dict__)
 


### PR DESCRIPTION
Ran into this problem with the Azure DNS provider when updating octoDNS to support Python 3 in https://github.com/github/octodns/pull/384. It looks like objects that implement `__eq__` in Python 3 are also required to implement a custom `__hash__` method to match. `RecordSet` in `azure-mgmt-dns==3.0.0` inherits from `Model` leading to:

```
(env3)otter:octodns ross$ ./script/coverage tests/test_octodns_provider_azuredns.py 2>&1 | tee /tmp/run.log
....E....
======================================================================
ERROR: test_populate_records (test_octodns_provider_azuredns.TestAzureDnsProvider)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ross/github/octodns/tests/test_octodns_provider_azuredns.py", line 449, in test_populate_records
    exists = provider.populate(zone)
  File "/Users/ross/github/octodns/octodns/provider/azuredns.py", line 386, in populate
    _records.add(azrecord)
TypeError: unhashable type: 'RecordSet'
```

I haven't dug around to see if there are other objects in `msrest` that need similar updates.

The actual hashing logic seems reasonable to me, but I'd welcome suggested improvements.