### PR TITLE
Improve XML support for msrest

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,13 @@ To install:
 Release History
 ---------------
 
+2019-12-19 Version 0.6.11
++++++++++++++++++++++++++
+
+**Features**
+
+- XML mode can now be enabled even if the given Model has no XML metadata  #184
+
 2019-09-04 Version 0.6.10
 +++++++++++++++++++++++++
 

--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -484,7 +484,7 @@ class Serializer(object):
                     if is_xml_model_serialization:
                         xml_desc = attr_desc['xml']
                         xml_name = xml_desc['name']
-                        if "attr" in xml_desc and xml_desc["attr"]:
+                        if xml_desc.get("attr", False):
                             serialized.set(xml_name, new_attr)
                             continue
                         if isinstance(new_attr, list):
@@ -796,7 +796,7 @@ class Serializer(object):
             xml_name = xml_desc['name']
 
             # Create a wrap node if necessary (use the fact that Element and list have "append")
-            is_wrapped = "wrapped" in xml_desc and xml_desc["wrapped"]
+            is_wrapped = xml_desc.get("wrapped", False)
             node_name = xml_desc.get("itemsName", xml_name)
             if is_wrapped:
                 final_result = _create_xml_node(
@@ -1115,7 +1115,7 @@ def xml_key_extractor(attr, attr_desc, data):
     xml_ns = xml_desc.get('ns', None)
 
     # If it's an attribute, that's simple
-    if "attr" in xml_desc and xml_desc["attr"]:
+    if xml_desc.get("attr", False):
         return data.get(xml_name)
 
     # Integrate namespace if necessary
@@ -1127,7 +1127,7 @@ def xml_key_extractor(attr, attr_desc, data):
 
     # Look for a children
     is_iter_type = attr_desc['type'].startswith("[")
-    is_wrapped = "wrapped" in xml_desc and xml_desc["wrapped"]
+    is_wrapped = xml_desc.get("wrapped", False)
     internal_type = attr_desc.get("internalType", None)
 
     # Scenario where I take the local name:

--- a/msrest/version.py
+++ b/msrest/version.py
@@ -25,4 +25,4 @@
 # --------------------------------------------------------------------------
 
 #: version of this package. Use msrest.__version__ instead
-msrest_version = "0.6.10"
+msrest_version = "0.6.11"

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='msrest',
-    version='0.6.10',
+    version='0.6.11',
     author='Microsoft Corporation',
     packages=find_packages(exclude=["tests", "tests.*"]),
     url=("https://github.com/Azure/msrest-for-python"),


### PR DESCRIPTION
This allows to serialize as XML, even a model that has no XML meta-data. Currently, only models with XML metadata could be serialize as XML.

Example:
```
In [3]:         class MyModel(Model):
   ...:             _validation = {
   ...:                 'id': {'readonly': True},
   ...:                 'name': {'required': True},
   ...:             }
   ...:             _attribute_map = {
   ...:                 'id': {'key': 'id', 'type': 'str'},
   ...:                 'name': {'key': 'name', 'type': 'str'},
   ...:                 'location': {'key': 'location', 'type': 'str'},
   ...:             }
   ...:             def __init__(self, **kwargs):
   ...:                 super(MyModel, self).__init__(**kwargs)
   ...:                 self.id = None
   ...:                 self.name = kwargs.get('name', None)
   ...:                 self.location = kwargs.get('location', None)

In [7]: ET.dump(MyModel(name="test", id="123").serialize(is_xml=True))
Readonly attribute id will be ignored in class <class '__main__.MyModel'>
<MyModel><name>test</name></MyModel>
```

would not have worked before.

This is needed since new Autorest based on Modeler4 will not expose extra-metadata