### PR TITLE
Fix TypeError: 'NoneType' object is not iterable during deserialization

### DIFF
--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -1086,7 +1086,7 @@ def rest_key_extractor(attr, attr_desc, data):
     key = attr_desc['key']
     working_data = data
 
-    while '.' in key:
+    while '.' in key and working_data:
         dict_keys = _FLATTEN.split(key)
         if len(dict_keys) == 1:
             key = _decode_attribute_map_key(dict_keys[0])
@@ -1101,7 +1101,7 @@ def rest_key_case_insensitive_extractor(attr, attr_desc, data):
     key = attr_desc['key']
     working_data = data
 
-    while '.' in key:
+    while '.' in key and working_data:
         dict_keys = _FLATTEN.split(key)
         if len(dict_keys) == 1:
             key = _decode_attribute_map_key(dict_keys[0])


### PR DESCRIPTION
msrest can't handle attribute map >= 3 layers during deserialization. 

For example, for [LongTermEnvironmentCreateOrUpdateParameters](https://github.com/Azure/azure-sdk-for-python/blob/af4ffee5a2aaa54f256f3577d0ca91f29a94e269/sdk/timeseriesinsights/azure-mgmt-timeseriesinsights/azure/mgmt/timeseriesinsights/models/_models_py3.py#L1469)

```py
'data_retention': {'key': 'properties.warmStoreConfiguration.dataRetention', 'type': 'duration'},
```

`properties.warmStoreConfiguration.dataRetention` has 3 layers. The regex matching this pattern is
```regex
'properties\..+?\..+?'
```

The CLI code I use to construct the body is 
```py
body = {}
body['kind'] = 'LongTerm'
body['location'] = location  # str
body['tags'] = tags  # dictionary
body.setdefault('sku', {})['name'] = sku_name  # str
body.setdefault('sku', {})['capacity'] = sku_capacity  # number
body['time_series_id_properties'] = [{"name": "deviceId", "type": "String"}, {"name": "deviceId2", "type": "String"}]  # [TimeSeriesIdProperty]
body['storage_configuration'] = {"account_name": storage_account_name, "management_key": storage_management_key}  # LongTermStorageConfigurationInput
body['data_retention'] = data_retention
return client.create_or_update(resource_group_name=resource_group, environment_name=name, parameters=body)
```


Got error:

```
cli.azure.cli.core.util : Unable to build a model: Unable to deserialize to object: type, TypeError: 'NoneType' object is not iterable, DeserializationError: Unable to deserialize to object: type, TypeError: 'NoneType' object is not iterable
Traceback (most recent call last):
  File "d:\cli\msrest-for-python\msrest\serialization.py", line 1328, in _deserialize
    found_value = key_extractor(attr, attr_desc, data)
  File "d:\cli\msrest-for-python\msrest\serialization.py", line 1110, in rest_key_case_insensitive_extractor
    working_data = attribute_key_case_insensitive_extractor(working_key, None, working_data)
  File "d:\cli\msrest-for-python\msrest\serialization.py", line 1132, in attribute_key_case_insensitive_extractor
    for key in data:
TypeError: 'NoneType' object is not iterable
```

This is because it first tries to extract `properties` from the body and gets `None`, but it doesn’t stop there because `warmStoreConfiguration.dataRetention` still has `.` and it continues to extract `warmStoreConfiguration` from `None` which results in an error. 

This PR makes the loop continue only if `working_data` evaluates to `True`.

