### PR TITLE
Fix model serialization

### DIFF
--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -953,7 +953,7 @@ class Serializer(object):
             return self.serialize_long(attr)
 
         # If it's a model or I know this dependency, serialize as a Model
-        elif obj_type in self.dependencies.values() or isinstance(obj_type, Model):
+        elif obj_type in self.dependencies.values() or isinstance(attr, Model):
             return self._serialize(attr)
 
         if obj_type == dict:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -312,6 +312,28 @@ class TestRuntimeSerialized(unittest.TestCase):
         assert s.query("filter", [',', ',', ','], "[str]", div=",") == "%2C,%2C,%2C"
         assert s.query("filter", [',', ',', ','], "[str]", div="|", skip_quote=True) == ",|,|,"
 
+    def test_serialize_custom_model(self):
+
+        class CustomSample(Model):
+            _validation = {
+                    'a': {'required': True},
+            }
+
+            _attribute_map = {
+                'a': {'key': 'a', 'type': 'str'},
+            }
+
+            def __init__(self, a):
+                self.a = a
+
+        s = Serializer()
+        model = CustomSample("helloworld")
+        serialized = s._serialize(model)
+
+        assert serialized is not None
+        assert isinstance(serialized, dict)
+        assert serialized['a'] == "helloworld"
+
     def test_serialize_direct_model(self):
         testobj = self.TestObj()
         testobj.attr_a = "myid"


### PR DESCRIPTION
msrest serializes objects as a string rather than dictionary

Please look at https://github.com/Azure/azure-sdk-for-python/issues/12831
```
class CustomSample(msrest.serialization.Model):
    _validation = {
            'a': {'required': True},
    }

    _attribute_map = {
        'a': {'key': 'a', 'type': 'str'},
    }

    def __init__(self, a):
        self.a = a
```
would be serialized as 'data': "{'a': 'sample event'}", (as an instance of string rather than dict)


Fixes https://github.com/Azure/azure-sdk-for-python/issues/12831