### PR TITLE
Update requests to 2.25.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Topic :: Software Development'],
     install_requires=[
-        "requests~=2.16",
+        "requests~=2.25",
         "requests_oauthlib>=0.5.0",
         "isodate>=0.6.0",
         "certifi>=2017.4.17",


### PR DESCRIPTION
Requests versions prior to 2.20 are vulnerable to https://cve.circl.lu/cve/CVE-2018-18074. This change updates the version of Requests used.