### PR TITLE
Validate "pattern" with re.search() instead of re.match()

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -12,3 +12,4 @@ aiohttp;python_full_version>="3.5.2"
 # async in msrest was experimental, we won't update
 trio==0.14.0;python_version == '3.5'
 trio==0.16.0;python_version >= '3.6'
+types-requests

--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -438,7 +438,7 @@ class Serializer(object):
         "maximum_ex": lambda x, y: x >= y,
         "min_items": lambda x, y: len(x) < y,
         "max_items": lambda x, y: len(x) > y,
-        "pattern": lambda x, y: not re.match(y, x, re.UNICODE),
+        "pattern": lambda x, y: not re.search(y, x, re.UNICODE),
         "unique": lambda x, y: len(x) != len(set(x)),
         "multiple": lambda x, y: x % y != 0
         }

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -418,6 +418,7 @@ class TestRuntimeSerialized(unittest.TestCase):
         # Assert not necessary, should not raise exception
         self.s.validate("simplestring", "StringForLog", pattern="^[a-z]+$")
         self.s.validate(u"UTF8ééééé", "StringForLog", pattern=r"^[\w]+$")
+        self.s.validate("begin middle end", "StringForLog", pattern="middle")
 
     def test_model_validate(self):
 


### PR DESCRIPTION
The re.match() method only looks for the regex at the beginning of the input, but the JSON Schema rules for "pattern" (as referenced by the Swagger/OpenAPI spec), state that "regular expressions are not implicitly anchored".

The result of using re.match() is that some valid values are rejected during client-side validation, if the pattern was written to match against something other than the start of the string. Using re.search() removes this implicit front-anchoring, so these values are not rejected.

A link for reference: http://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.3.3