### PR TITLE
fix duplicate serialization for list items in query

### DIFF
--- a/msrest/serialization.py
+++ b/msrest/serialization.py
@@ -676,18 +676,8 @@ class Serializer(object):
             # Treat the list aside, since we don't want to encode the div separator
             if data_type.startswith("["):
                 internal_data_type = data_type[1:-1]
-                data = [
-                    self.serialize_data(d, internal_data_type, **kwargs) if d is not None else ""
-                    for d
-                    in data
-                ]
-                if not kwargs.get('skip_quote', False):
-                    data = [
-                        quote(str(d), safe='')
-                        for d
-                        in data
-                    ]
-                return str(self.serialize_iter(data, internal_data_type, **kwargs))
+                do_quote = not kwargs.get('skip_quote', False)
+                return str(self.serialize_iter(data, internal_data_type, do_quote=do_quote, **kwargs))
 
             # Not a list, regular serialization
             output = self.serialize_data(data, data_type, **kwargs)
@@ -866,6 +856,13 @@ class Serializer(object):
                 if isinstance(err, SerializationError):
                     raise err
                 serialized.append(None)
+
+        if kwargs.get('do_quote', False):
+            serialized = [
+                '' if s is None else quote(str(s), safe='')
+                for s
+                in serialized
+            ]
 
         if div:
             serialized = ['' if s is None else str(s) for s in serialized]

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -313,6 +313,18 @@ class TestRuntimeSerialized(unittest.TestCase):
         assert s.query("filter", ['a', None, 'c'], "[str]", div=",") == "a,,c"
         assert s.query("filter", [',', ',', ','], "[str]", div=",") == "%2C,%2C,%2C"
         assert s.query("filter", [',', ',', ','], "[str]", div="|", skip_quote=True) == ",|,|,"
+        assert s.query("filter", [
+            datetime(2022, 8, 26, 17, 38, 0),
+            datetime(2022, 8, 26, 18, 38, 0),
+            datetime(2022, 8, 26, 19, 38, 0),
+        ], "[iso-8601]", div=","
+                       ) == "2022-08-26T17%3A38%3A00.000Z,2022-08-26T18%3A38%3A00.000Z,2022-08-26T19%3A38%3A00.000Z"
+        assert s.query("filter", [
+            datetime(2022, 8, 26, 17, 38, 0),
+            datetime(2022, 8, 26, 18, 38, 0),
+            datetime(2022, 8, 26, 19, 38, 0),
+        ], "[iso-8601]", div=",", skip_quote=True
+                       ) == "2022-08-26T17:38:00.000Z,2022-08-26T18:38:00.000Z,2022-08-26T19:38:00.000Z"
 
     def test_serialize_custom_model(self):
 


### PR DESCRIPTION
Previously logic did serialization for list item in query twice, and the second serialization will fall in an error logic when parse str [here](https://github.com/Azure/msrest-for-python/blob/069957fd28a1eeb5d458ac435baab87bceb811cd/msrest/serialization.py#L1117).
The new logic keep most the same as previous flag and logic of `serialize_iter`, only try to prevent the duplicate serialization.
Concrete example could be seen in tests.