### PR TITLE
Fix tests on Python 3.12

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -111,7 +111,10 @@ class TestAuthentication(unittest.TestCase):
         )
         session = auth.signed_session()
         prep_req = session.prepare_request(self.request)
-        self.assertDictContainsSubset({'testheader' : 'testheadervalue'}, prep_req.headers)
+        self.assertLessEqual(
+            {'testheader': 'testheadervalue'}.items(),
+            prep_req.headers.items(),
+        )
 
         auth = ApiKeyCredentials(
             in_query={
@@ -126,19 +129,28 @@ class TestAuthentication(unittest.TestCase):
         auth = CognitiveServicesCredentials("mysubkey")
         session = auth.signed_session()
         prep_req = session.prepare_request(self.request)
-        self.assertDictContainsSubset({'Ocp-Apim-Subscription-Key' : 'mysubkey'}, prep_req.headers)
+        self.assertLessEqual(
+            {'Ocp-Apim-Subscription-Key': 'mysubkey'}.items(),
+            prep_req.headers.items(),
+        )
 
     def test_eventgrid_auth(self):
         auth = TopicCredentials("mytopickey")
         session = auth.signed_session()
         prep_req = session.prepare_request(self.request)
-        self.assertDictContainsSubset({'aeg-sas-key' : 'mytopickey'}, prep_req.headers)
+        self.assertLessEqual(
+            {'aeg-sas-key': 'mytopickey'}.items(),
+            prep_req.headers.items(),
+        )
 
     def test_eventgrid_domain_auth(self):
         auth = DomainCredentials("mydomainkey")
         session = auth.signed_session()
         prep_req = session.prepare_request(self.request)
-        self.assertDictContainsSubset({'aeg-sas-key' : 'mydomainkey'}, prep_req.headers)
+        self.assertLessEqual(
+            {'aeg-sas-key': 'mydomainkey'}.items(),
+            prep_req.headers.items(),
+        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{36,37,38,39,310,311}
+envlist=py{36,37,38,39,310,311,312}
 skipsdist=True
 
 [testenv]


### PR DESCRIPTION
Fixes #261.

This PR handles the removal of the [long-deprecated `assertDictContainsSubset` test method](https://docs.python.org/dev/whatsnew/3.12.html#id3) by following the guidance from [the old deprecation notice](https://docs.python.org/3.2/library/unittest.html?highlight=assertdictcontainssubset#unittest.TestCase.assertDictContainsSubset).